### PR TITLE
refs #task_04 - Support Different Delimiters

### DIFF
--- a/src/hari/tdd/assessment/StringCalculator.java
+++ b/src/hari/tdd/assessment/StringCalculator.java
@@ -20,6 +20,12 @@ public class StringCalculator {
 			return 0; // For an empty string it will return 0.
 		}
 
+		if (inputString.startsWith("//")) {
+			String delimeterInput = inputString.substring(2, inputString.indexOf("\n"));
+			inputString = inputString.substring(inputString.indexOf("\n") + 1, inputString.length());
+			inputString = inputString.replace(delimeterInput, ",");
+		}
+
 		String[] inputArray = inputString.split("[,\n]"); // Split by both commas and newLines
 
 		if (inputArray.length == 1) {

--- a/src/test/StringCalculatorTest.java
+++ b/src/test/StringCalculatorTest.java
@@ -50,4 +50,15 @@ public class StringCalculatorTest {
 		assertEquals(stringCalculator.add("10,20\n30,40"), 100);
 	}
 
+	// TASK 4 - Support different delimiters “//[delimiter]\n[numbers…]”
+	@Test
+	public void testDifferentDelimiters() {
+		assertEquals(stringCalculator.add("//;\n1;2"), 3); // where the default delimiter is ‘;’
+		assertEquals(stringCalculator.add("//#\n1#2"), 3);
+
+		assertEquals(stringCalculator.add("//#$\n1#$2#$3"), 6);
+
+		assertEquals(stringCalculator.add("//-$^$-\n1-$^$-2-$^$-3"), 6);
+	}
+
 }


### PR DESCRIPTION
- To change a delimiter, the beginning of the string will contain a separate line that looks like this: “**//[delimiter]\n[numbers…]**”
- For example “**//;\n1;2**” should return three where the default delimiter is ‘;’ .
- The first line is optional. all existing scenarios should still be supported